### PR TITLE
remove leading underbars from function names in flatlands_env

### DIFF
--- a/gym_flatlands/demo_flatlands.py
+++ b/gym_flatlands/demo_flatlands.py
@@ -28,9 +28,9 @@ def sim_demo():
                 "wheel_angle": theta,
             }
 
-            obs = flatlands._step(action)
+            obs = flatlands.step(action)
 
-            flatlands._render()
+            flatlands.render()
 
             # x and y distance to the 3rd point ahead (in meters)
             point = obs["dist_upcoming_points"][3]
@@ -38,7 +38,7 @@ def sim_demo():
             # x and y form a right triangle, the angle towards which we want to go is their atan
             theta = math.atan(point[0] / point[1])
 
-        flatlands._reset()
+        flatlands.reset()
 
 
 if __name__ == "__main__":

--- a/gym_flatlands/envs/flatlands_env.py
+++ b/gym_flatlands/envs/flatlands_env.py
@@ -30,7 +30,7 @@ class FlatlandsEnv(gym.Env):
 
         self.car_info = None
 
-    def _step(self, action):
+    def step(self, action):
         """
         Accepts an `action` object, consisting of desired accelleration (accel)
         and the steering angle
@@ -52,7 +52,7 @@ class FlatlandsEnv(gym.Env):
 
         return obs
 
-    def _reset(self):
+    def reset(self):
         """
         Reset the car to a static place somewhere on the track.
         """
@@ -67,7 +67,7 @@ class FlatlandsEnv(gym.Env):
 
         self.distance_traveled = 0
 
-    def _render(self, mode='human', close=False):
+    def render(self, mode='human', close=False):
         """
         Use pygame to draw the map
         """


### PR DESCRIPTION
I tested on the `demo_flatlands` that calls this env.